### PR TITLE
Publish test coverage to coveralls.io

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -26,4 +26,10 @@ jobs:
     - name: Tests
       run: |
         dotnet restore
-        dotnet test
+        dotnet test /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:CoverletOutputFormat=lcov
+
+    - name: Publish coverage report to coveralls.io   
+      uses: coverallsapp/github-action@master   
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }} 
+        path-to-lcov: tests/CycloneDX.BomRepoServer.Tests/TestResults/coverage.info

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ bin/
 obj/
 *.user
 repo/
+
+# MSTest test Results
+[Tt]est[Rr]esult*/
+[Bb]uild[Ll]og.*

--- a/tests/CycloneDX.BomRepoServer.Tests/CycloneDX.BomRepoServer.Tests.csproj
+++ b/tests/CycloneDX.BomRepoServer.Tests/CycloneDX.BomRepoServer.Tests.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="14.0.13" />


### PR DESCRIPTION
With this PR coverage is published to coveralls.io. I believe an admin of CycloneDx (?) would need to sign up for coveralls and add this repository in order to have the results processed. After that pull requests will have an additional check where coverage is reported.